### PR TITLE
Fix for latest Fire OS restriction on changing settings via adb (Proof of concept)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS"/>
+    <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/baronkiko/launcherhijack/MainActivity.java
+++ b/app/src/main/java/com/baronkiko/launcherhijack/MainActivity.java
@@ -229,6 +229,10 @@ public class MainActivity extends AppCompatActivity
 
         super.onCreate(savedInstanceState);
 
+        String packageName = getApplicationContext().getPackageName();
+        Settings.Secure.putString(getContentResolver(), "enabled_accessibility_services", packageName+"/"+packageName+".AccServ");
+        Settings.Secure.putString(getContentResolver(), "accessibility_enabled", "1");
+
         if (!isAccessibilityEnabled(context, "com.baronkiko.launcherhijack/.AccServ"))
         {
             AlertDialog.Builder builder = new AlertDialog.Builder(this)


### PR DESCRIPTION
Note: This is just a proof of concept, it could break something if done like this.

This fixes the restriction introduced by the latest FireOS version (at least on Fire TVs): the setting enabled_accessibility_services cannot be changed anymore via adb, however it can still be changed via application. Hence the solution: change it via LauncherHijack itself. This way, instead of setting the accessibility variables manually, the users just need to grant LauncherHijack the required system permission:

`adb shell pm grant com.baronkiko.launcherhijack android.permission.WRITE_SECURE_SETTINGS`