### PR TITLE
Fix NPE in AccServ.onAccessibilityEvent

### DIFF
--- a/app/src/main/java/com/baronkiko/launcherhijack/AccServ.java
+++ b/app/src/main/java/com/baronkiko/launcherhijack/AccServ.java
@@ -28,7 +28,7 @@ public class AccServ extends AccessibilityService {
             return;
 
         CharSequence packageName = event.getPackageName();
-        if (packageName.equals("com.amazon.firelauncher"))
+        if (packageName != null && packageName.equals("com.amazon.firelauncher"))
             HomePress.Perform(getApplicationContext());
     }
 


### PR DESCRIPTION
Add NPE guard to prevent errors on AccessibilityEvents that do not have context about a package

>     java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Object.equals(java.lang.Object)' on a null object reference
>         at com.baronkiko.launcherhijack.AccServ.onAccessibilityEvent(AccServ.java:31)
>         at android.accessibilityservice.AccessibilityService$2.onAccessibilityEvent(AccessibilityService.java:1538)
>         at android.accessibilityservice.AccessibilityService$IAccessibilityServiceClientWrapper.executeMessage(AccessibilityService.java:1724)
>         at com.android.internal.os.HandlerCaller$MyHandler.handleMessage(HandlerCaller.java:37)
>         at android.os.Handler.dispatchMessage(Handler.java:106)
>         at android.os.Looper.loop(Looper.java:193)
>         at android.app.ActivityThread.main(ActivityThread.java:6734)
>         at java.lang.reflect.Method.invoke(Native Method)
>         at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
>         at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)